### PR TITLE
Fix error in About Us link-cag

### DIFF
--- a/cypress/integration/landing_page_spec.js
+++ b/cypress/integration/landing_page_spec.js
@@ -33,7 +33,7 @@ describe('Shared Milk landing page user flow', () => {
   it('should be able to navigate to the About Us page view', () => {
     cy.get('.nav').contains('About Us').click()
     cy.location().should((location => {
-      expect(location.href).to.eq('http://localhost:3000/about-us')
+      expect(location.href).to.eq('http://localhost:3000/about')
     }))
   })
 


### PR DESCRIPTION
Is this a fix or a feature?
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
 
Describe the feature - fix - refactor:
- Changed `/about-me` path to `/about` to fix failing test

How was this tested?
- [ ] open index.html
- [ ] localhost
- [X] terminal

Where should the reviewer start - test:

- npm run cypress or circleCI testing

Additional comments:

Thanks y'all!
